### PR TITLE
Add structured pipeline logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "ufp_canonical",
  "ufp_ingest",
  "ufp_perceptual",
+ "ufp_semantic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 ufp_canonical = { path = "crates/ufp_canonical" }
 ufp_ingest = { path = "crates/ufp_ingest" }
 ufp_perceptual = { path = "crates/ufp_perceptual" }
+ufp_semantic = { path = "crates/ufp_semantic" }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -181,10 +181,22 @@ let (doc, fingerprint) =
     process_record_with_perceptual(record, &canonical_cfg, &perceptual_cfg)?;
 assert_eq!(doc.canonical_text, "hello world");
 assert_eq!(fingerprint.meta.k, 5);
+
+let semantic_cfg = SemanticConfig {
+    mode: "fast".into(),
+    tier: "fast".into(),
+    ..Default::default()
+};
+let embedding = semanticize_document(&doc, &semantic_cfg)?;
+assert_eq!(embedding.doc_id, doc.doc_id);
 ```
 
+Call `process_record_with_semantic(...)` to obtain the document and embedding together, or
+`semanticize_document(...)` when you already have a canonical document on hand.
+
 Failures bubble up as `PipelineError::Ingest(_)`, `PipelineError::Canonical(_)`,
-`PipelineError::Perceptual(_)`, or `PipelineError::NonTextPayload`. The CLI binary in `src/main.rs`
+`PipelineError::Perceptual(_)`, `PipelineError::Semantic(_)`,
+or `PipelineError::NonTextPayload`. The CLI binary in `src/main.rs`
 invokes `big_text_demo` and prints the final MinHash signature generated from
 `crates/ufp_canonical/examples/big_text.txt`.
 
@@ -198,6 +210,7 @@ such as:
 timestamp="2025-02-10T02:15:01.234Z" stage=ingest status=success latency_us=640 record_id="demo"
 timestamp="2025-02-10T02:15:01.241Z" stage=canonical status=success latency_us=488 record_id="demo" doc_id="demo"
 timestamp="2025-02-10T02:15:01.245Z" stage=perceptual status=success latency_us=377 record_id="demo" doc_id="demo"
+timestamp="2025-02-10T02:15:01.249Z" stage=semantic status=success latency_us=512 record_id="demo" doc_id="demo"
 ```
 
 `examples/pipeline_metrics.rs` now wires both metrics and structured logging. Run it with:


### PR DESCRIPTION
## Summary
- add PipelineStage/PipelineEvent structured logging, KeyValueLogger helper, and set_pipeline_logger
- integrate structured spans so ingest/canonical/perceptual emit both metrics and key/value events
- update README and pipeline_metrics example to document the new observability outputs

## Testing
- cargo fmt --all -- --check
- cargo clippy --all --all-targets -- -D warnings
- cargo test --all