### PR TITLE
Update crate-level and README documentation for UCFP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Universal Content Fingerprinting (UCFP)
 
 UCFP (Universal Content Fingerprint) is an open-source framework for generating unique, reproducible,
-and meaning-aware fingerprints across text, audio, image, video, and document payloads. It unifies 
-exact hashing, perceptual similarity, and semantic embeddings into one coherent pipeline,so developers
+and meaning-aware fingerprints across text, audio, image, video, and document payloads. It unifies
+exact hashing, perceptual similarity, and semantic embeddings into one coherent pipeline, so developers
 can identify, compare, and link content deterministically and perceptually. Built in Rust for speed and
 reliability, UCFP powers use cases such as deduplication, plagiarism detection, data cleaning, 
 content provenance, and multimodal search.
@@ -18,10 +18,11 @@ content provenance, and multimodal search.
   similarity search and near-duplicate detection straightforward.
 - **Semantic embeddings** – `ufp_semantic` turns canonical text into ONNX/API-backed dense vectors
   with deterministic fallbacks for offline tiers.
-- **Single entry point** – the root `ucfp` crate wires every stage into `process_record` and
-  `process_record_with_perceptual`, so applications can adopt the full pipeline one call at a time.
+- **Single entry point** – the root `ucfp` crate wires every stage into `process_record`,
+  `process_record_with_perceptual`, and `process_record_with_semantic`, so applications can adopt the
+  full pipeline one call at a time.
 - **Built-in observability** – plug in a `PipelineMetrics` recorder to capture latency and results for
-  ingest, canonical, and perceptual stages.
+  ingest, canonical, perceptual, and semantic stages.
 
 ## Use cases
 
@@ -77,9 +78,11 @@ The root `ucfp` crate re-exports all public types and orchestrates the stages th
 
 - `process_record` (ingest + canonicalize),
 - `process_record_with_perceptual` (full ingest → canonical → perceptual),
+- `process_record_with_semantic` (ingest → canonical → semantic embedding),
 - `process_record_with_*_configs` helpers when explicit configuration objects are needed,
+- `process_semantic_document` / `semanticize_document` when you need only the embedding,
 - `big_text_demo` for the bundled integration example,
-- `set_pipeline_metrics` / `PipelineMetrics` for observability hooks.
+- `set_pipeline_metrics` / `PipelineMetrics` and `set_pipeline_logger` for observability hooks.
 
 ### Layer responsibilities
 
@@ -159,7 +162,7 @@ assert_eq!(doc.canonical_text, "streamlined config demo");
 use chrono::{Duration, Utc};
 use ucfp::{
     CanonicalizeConfig, IngestMetadata, IngestPayload, IngestSource, PerceptualConfig,
-    RawIngestRecord, process_record_with_perceptual,
+    RawIngestRecord, SemanticConfig, process_record_with_perceptual, semanticize_document,
 };
 
 let canonical_cfg = CanonicalizeConfig::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,28 @@
 //! Workspace umbrella crate for Universal Content Fingerprinting (UCFP).
 //!
-//! This crate stitches together ingest normalization and canonicalization so
-//! callers can operate over text payloads with a single API entry point.
+//! The `ucfp` crate re-exports the ingest, canonical, perceptual, and semantic
+//! layers so applications can drive the full pipeline through a single
+//! dependency. Helpers such as [`process_record_with_configs`],
+//! [`process_document_with_configs`], and [`process_record_with_semantic`]
+//! orchestrate the stages end-to-end, while lighter wrappers like
+//! [`process_document`] and [`process_semantic_document`] provide the common
+//! "just give me the fingerprint/embedding" entry points.
+//!
+//! ## Observability
+//!
+//! Metrics and structured logs can be captured by installing a
+//! [`PipelineMetrics`] recorder via [`set_pipeline_metrics`] and/or a
+//! [`PipelineEventLogger`] with [`set_pipeline_logger`]. Both hooks report
+//! latency, stage success/failure, and identifiers derived from the ingest or
+//! canonical steps.
+//!
+//! ## Errors
+//!
+//! Failures produced by any layer converge on [`PipelineError`], which maps the
+//! source error and preserves metadata for downstream handling. Callers can
+//! distinguish between ingest, canonical, perceptual, semantic, or
+//! non-text-payload failures without needing to depend on the individual
+//! workspace crates.
 
 pub use ufp_canonical::{
     CanonicalError, CanonicalizeConfig, CanonicalizedDocument, Token, canonicalize,


### PR DESCRIPTION
## Summary
- expand the crate-level documentation to describe orchestrated helpers, observability hooks, and unified errors
- update the README to mention semantic helpers, logger hooks, and fix minor wording issues
- correct README code imports so the example highlights the semantic helpers now referenced

## Testing
- not run (docs only)
